### PR TITLE
chore: create ci workflow skeleton

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+on:
+    pull_request:
+        branches:
+          - main
+
+jobs:
+    lint-and-test:
+        name: Lint and Test
+        runs-on: ubuntu
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+
+            - name: Lint
+              uses:
+
+            - name: Run tests
+              uses: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,8 @@ services:
     environment:
       DEBUG: true
       SECRET_KEY: your_secret_key_here
-      GITHUB_OAUTH_CLIENT_ID: 918ef50cd94282d71b1b
-      GITHUB_OAUTH_CLIENT_SECRET: 9d8242fe2293c6d8784f48ee6ba6117d1cb4e748
+      GITHUB_OAUTH_CLIENT_ID: 106c8f10e10a59a7d9f8
+      GITHUB_OAUTH_CLIENT_SECRET: eedf85ff88d3a1f23fee6c1a2cf91b6cb750c134
       # these must match the mysql params
       MYSQL_DATABASE_USER: GH_Miner_usr
       MYSQL_DATABASE_PASSWORD: GH_Miner_pswrd


### PR DESCRIPTION
This creates a skeleton for the ci GitHub Action. I left steps open for the linter and running tests. For the linter, I would suggest using ruff - see https://github.com/astral-sh/ruff. For the testing step, there's a lot of ways to do it but just googling it should provide some answers.